### PR TITLE
Legger personikon ved siden av brukernavn og fnr

### DIFF
--- a/templates/syfosoknader/arbeidstakere.hbs
+++ b/templates/syfosoknader/arbeidstakere.hbs
@@ -13,30 +13,33 @@
 </div>
 <div class="container">
     <div class="personinfo">
-        <img class="personikon" src="{{ image "Personikon.png" }}"/>
         <div class="persontekst">
-            <div class="sendt">
-                {{# if korrigerer}}
-                    <p class="korrigert">Korrigert</p>
-                {{/if}}
-                {{# if innsendtDato}}
-                    <p>
-                        Sendt til NAV<br/>{{ iso_to_date innsendtDato }}
+            <div class="persontekst__sidetopp">
+                <img class="personikon" src="{{ image "Personikon.png" }}"/>
+                <div class="persontekst__personalia">
+                    <p class="navn">
+                        {{ navn }}
                     </p>
-                {{/if}}
-                {{# if sendtArbeidsgiver}}
-                    <p>
-                        Sendt til arbeidsgiver<br/>{{ iso_to_date sendtArbeidsgiver }}
+                    <p class="id">
+                        {{ insert_at fnr 6 }}
                     </p>
-                {{/if}}
+                </div>
+                <div class="sendt">
+                    {{# if korrigerer}}
+                        <p class="korrigert">Korrigert</p>
+                    {{/if}}
+                    {{# if innsendtDato}}
+                        <p>
+                            Sendt til NAV<br/>{{ iso_to_date innsendtDato }}
+                        </p>
+                    {{/if}}
+                    {{# if sendtArbeidsgiver}}
+                        <p>
+                            Sendt til arbeidsgiver<br/>{{ iso_to_date sendtArbeidsgiver }}
+                        </p>
+                    {{/if}}
+                </div>
             </div>
-
-            <p class="navn">
-                {{ navn }}
-            </p>
-            <p class="id">
-                {{ insert_at fnr 6 }}
-            </p>
 
             {{# each soknadPerioder as |periode|~}}
                 <p class="header__tittel">

--- a/templates/syfosoknader/partials/style.hbs
+++ b/templates/syfosoknader/partials/style.hbs
@@ -120,7 +120,7 @@
     .personikon {
         display: inline-block;
         width: 32px;
-        margin-right: 4px;
+        margin-right: 8px;
         margin-left: 3px;
     }
 
@@ -130,9 +130,19 @@
     }
 
     .sendt {
+        display: inline-block;
         float: right;
         width: 145px;
         font-size: 14px;
+    }
+
+    .persontekst__personalia {
+        display: inline-block;
+    }
+
+    .persontekst__sidetopp {
+        display: block;
+        margin-bottom: 32px;
     }
 
     .sporsmalcontainer {


### PR DESCRIPTION
Gir ogsa mer luft mellom navn og sendt til datoer og periodeoversikt

Ser ut som om styles var CRLF og at jeg har formattert det til LF. Det jeg har gjort er:

```css
.personikon {
    display: inline-block;
    width: 32px;
    /* oppdatert margin-right: 4px; */
    margin-right: 8px;
    margin-left: 3px;
}

/* Lagt til: */
.persontekst__personalia {
    display: inline-block;
}

.persontekst__sidetopp {
    display: block;
    margin-bottom: 32px;
}
```

![image](https://user-images.githubusercontent.com/3852471/55143809-d3389100-513f-11e9-9f4c-3fb2d7058b8d.png)