### PR TITLE
Added option to format currency without showing decimals

### DIFF
--- a/src/main/kotlin/no/nav/pdfgen/Helpers.kt
+++ b/src/main/kotlin/no/nav/pdfgen/Helpers.kt
@@ -113,15 +113,19 @@ fun registerNavHelpers(handlebars: Handlebars) {
             }
         })
 
-        registerHelper("currency_no", Helper<Any> { context, _ ->
+        registerHelper("currency_no", Helper<Any> { context, options ->
             if (context == null) return@Helper ""
+            val withoutDecimals = options.param(0, false)
 
             val splitNumber = context.toString().split(".")
 
-            val formatedNumber = splitNumber.first().reversed().chunked(3).joinToString(" ").reversed()
-            val decimals = splitNumber.drop(1).firstOrNull()?.let { (it + "0").substring(0, 2) } ?: "00"
-
-            "$formatedNumber,$decimals"
+            val formattedNumber = splitNumber.first().reversed().chunked(3).joinToString(" ").reversed()
+            if(withoutDecimals){
+               formattedNumber
+            } else {
+                val decimals = splitNumber.drop(1).firstOrNull()?.let { (it + "0").substring(0, 2) } ?: "00"
+                "$formattedNumber,$decimals"
+            }
         })
     }
 }

--- a/src/test/kotlin/no/nav/pdfgen/HelperSpek.kt
+++ b/src/test/kotlin/no/nav/pdfgen/HelperSpek.kt
@@ -153,5 +153,10 @@ object HelperSpek : Spek({
             handlebars.compileInline("{{ currency_no beløp_integer }}").apply(context) shouldEqual "9 001,00"
             handlebars.compileInline("{{ currency_no beløp_stort }}").apply(context) shouldEqual "1 337 420,69"
         }
+
+        it("should format number as currency without decimals") {
+            handlebars.compileInline("{{ currency_no beløp true }}").apply(context) shouldEqual "1 337"
+            handlebars.compileInline("{{ currency_no beløp_stort true }}").apply(context) shouldEqual "1 337 420"
+        }
     }
 })


### PR DESCRIPTION
Added the possibility send in an optional parameter that decides whether or not decimals should be shown after formatting. We in Team SU need this kind of functionality.

Co-authored-by: Ramzi Abu Qassim <ramzi.abu.qassim@nav.no>
Co-authored-by: Ingar Almklov <ingar.almklov@nav.no>