### PR TITLE
Endret breaklines helper til å skrive breakline-tag som godtas av valideringen

### DIFF
--- a/src/main/kotlin/no/nav/pdfgen/template/Helpers.kt
+++ b/src/main/kotlin/no/nav/pdfgen/template/Helpers.kt
@@ -260,10 +260,10 @@ fun registerNavHelpers(handlebars: Handlebars, env: Environment) {
                 } else {
                     val santizedText = Handlebars.Utils.escapeExpression(context)
                     val withLineBreak = santizedText.toString()
-                        .replace("\\r\\n", "<br>")
-                        .replace("\\n", "<br>")
-                        .replace("\r\n", "<br>")
-                        .replace("\n", "<br>")
+                        .replace("\\r\\n", "<br/>")
+                        .replace("\\n", "<br/>")
+                        .replace("\r\n", "<br/>")
+                        .replace("\n", "<br/>")
                     Handlebars.SafeString(withLineBreak)
                 }
             }

--- a/src/test/kotlin/no/nav/pdfgen/HelperSpek.kt
+++ b/src/test/kotlin/no/nav/pdfgen/HelperSpek.kt
@@ -484,11 +484,11 @@ object HelperSpek : Spek({
         val context = jsonContext(jsonNodeFactory.objectNode())
 
         it("Should replace \\r\\n with newline") {
-            handlebars.compileInline("{{breaklines \"I pitty the fool \\r\\n Who doesn't br\"}}").apply(context) shouldBeEqualTo "I pitty the fool <br> Who doesn&#x27;t br"
+            handlebars.compileInline("{{breaklines \"I pitty the fool \\r\\n Who doesn't br\"}}").apply(context) shouldBeEqualTo "I pitty the fool <br/> Who doesn&#x27;t br"
         }
 
         it("Should replace \\n with newline") {
-            handlebars.compileInline("{{breaklines \"I pitty the fool \\n Who doesn't br\"}}").apply(context) shouldBeEqualTo "I pitty the fool <br> Who doesn&#x27;t br"
+            handlebars.compileInline("{{breaklines \"I pitty the fool \\n Who doesn't br\"}}").apply(context) shouldBeEqualTo "I pitty the fool <br/> Who doesn&#x27;t br"
         }
     }
 })


### PR DESCRIPTION
Applikasjoner som bruker siste docker-image vil oppleve feil ved bruk av ` {{breaklines ... }}` når det er avsnitt i teksten
