### PR TITLE
add helper for int to currency

### DIFF
--- a/src/main/kotlin/no/nav/pdfgen/template/Helpers.kt
+++ b/src/main/kotlin/no/nav/pdfgen/template/Helpers.kt
@@ -246,6 +246,28 @@ fun registerNavHelpers(handlebars: Handlebars, env: Environment) {
         )
 
         registerHelper(
+            "int_as_currency_no",
+            Helper<Int> { context, _ ->
+                val currency = context.toString().reversed().chunked(2) // 100050 -> "050001" -> ["05", "00", "01"]
+                val øre = currency.first().reversed().let {
+                    if (it.length == 1) {
+                        "0$it" // if we're receiving a number like 1 at the top, we should equal 0,01 and not 0,10
+                    } else {
+                        it
+                    }
+                } // "05" -> "50"
+                val kr = currency.drop(1).let {
+                    if (it.isEmpty()) {
+                        "0" // if we're receiving a number like 1 at the top, we need our 0 here
+                    } else {
+                        it.joinToString("").chunked(3).joinToString(" ").reversed() // ["00", "01"] -> "0001" -> ["000", "1"] -> "000 1" -> "1 000"
+                    }
+                }
+                "$kr,$øre" // 1 000,50
+            }
+        )
+
+        registerHelper(
             "is_defined",
             Helper<Any> { context, options ->
                 if (context != null) options.fn() else options.inverse()

--- a/src/test/kotlin/no/nav/pdfgen/HelperSpek.kt
+++ b/src/test/kotlin/no/nav/pdfgen/HelperSpek.kt
@@ -364,6 +364,10 @@ object HelperSpek : Spek({
                 put("beløp_single_decimal", 1337.6)
                 put("beløp_integer", 9001)
                 put("beløp_stort", 1337420.69)
+                put("beløp_ganske_liten_integer", 1)
+                put("beløp_kjempeliten_integer", 0)
+                put("beløp_liten_integer", 10)
+                put("beløp_stor_integer", 1000001)
             }
         )
 
@@ -377,6 +381,14 @@ object HelperSpek : Spek({
         it("should format number as currency without decimals") {
             handlebars.compileInline("{{ currency_no beløp true }}").apply(context) shouldBeEqualTo "1 337"
             handlebars.compileInline("{{ currency_no beløp_stort true }}").apply(context) shouldBeEqualTo "1 337 420"
+        }
+
+        it("should format integer to currency") {
+            handlebars.compileInline("{{ int_as_currency_no beløp_integer }}").apply(context) shouldBeEqualTo "90,01"
+            handlebars.compileInline("{{ int_as_currency_no beløp_liten_integer }}").apply(context) shouldBeEqualTo "0,10"
+            handlebars.compileInline("{{ int_as_currency_no beløp_kjempeliten_integer }}").apply(context) shouldBeEqualTo "0,00"
+            handlebars.compileInline("{{ int_as_currency_no beløp_ganske_liten_integer }}").apply(context) shouldBeEqualTo "0,01"
+            handlebars.compileInline("{{ int_as_currency_no beløp_stor_integer }}").apply(context) shouldBeEqualTo "10 000,01"
         }
     }
 


### PR DESCRIPTION
We're representing currency as an integer further upstream (100 becomes 1kr and 0 øre, 1 should become 0kr and 1 øre, and so on), and now we need a helper to convert this to the right format.
I'm avoiding any sort of casting to floats, so I've added comments where I think it's warranted to explain the logic.

(PS: I don't like the name of the helper, so I'm taking suggestions for any better names)