### PR TITLE
simplify int_as_currency_no

### DIFF
--- a/src/main/kotlin/no/nav/pdfgen/template/Helpers.kt
+++ b/src/main/kotlin/no/nav/pdfgen/template/Helpers.kt
@@ -249,7 +249,7 @@ fun registerNavHelpers(handlebars: Handlebars, env: Environment) {
             "int_as_currency_no",
             Helper<Int> { context, _ ->
                 val kr = context / 100
-                val øre = context - kr * 100
+                val øre = context % 100
 
                 "%,d,%02d".format(locale = Locale("nb"), kr, øre)
             }

--- a/src/main/kotlin/no/nav/pdfgen/template/Helpers.kt
+++ b/src/main/kotlin/no/nav/pdfgen/template/Helpers.kt
@@ -248,22 +248,10 @@ fun registerNavHelpers(handlebars: Handlebars, env: Environment) {
         registerHelper(
             "int_as_currency_no",
             Helper<Int> { context, _ ->
-                val currency = context.toString().reversed().chunked(2) // 100050 -> "050001" -> ["05", "00", "01"]
-                val øre = currency.first().reversed().let {
-                    if (it.length == 1) {
-                        "0$it" // if we're receiving a number like 1 at the top, we should equal 0,01 and not 0,10
-                    } else {
-                        it
-                    }
-                } // "05" -> "50"
-                val kr = currency.drop(1).let {
-                    if (it.isEmpty()) {
-                        "0" // if we're receiving a number like 1 at the top, we need our 0 here
-                    } else {
-                        it.joinToString("").chunked(3).joinToString(" ").reversed() // ["00", "01"] -> "0001" -> ["000", "1"] -> "000 1" -> "1 000"
-                    }
-                }
-                "$kr,$øre" // 1 000,50
+                val kr = context / 100
+                val øre = context - kr * 100
+
+                "%,d,%02d".format(locale = Locale("nb"), kr, øre)
             }
         )
 

--- a/src/test/kotlin/no/nav/pdfgen/HelperSpek.kt
+++ b/src/test/kotlin/no/nav/pdfgen/HelperSpek.kt
@@ -368,6 +368,7 @@ object HelperSpek : Spek({
                 put("beløp_kjempeliten_integer", 0)
                 put("beløp_liten_integer", 10)
                 put("beløp_stor_integer", 1000001)
+                put("beløp_kjempestor_integer", Int.MAX_VALUE)
             }
         )
 
@@ -388,7 +389,8 @@ object HelperSpek : Spek({
             handlebars.compileInline("{{ int_as_currency_no beløp_liten_integer }}").apply(context) shouldBeEqualTo "0,10"
             handlebars.compileInline("{{ int_as_currency_no beløp_kjempeliten_integer }}").apply(context) shouldBeEqualTo "0,00"
             handlebars.compileInline("{{ int_as_currency_no beløp_ganske_liten_integer }}").apply(context) shouldBeEqualTo "0,01"
-            handlebars.compileInline("{{ int_as_currency_no beløp_stor_integer }}").apply(context) shouldBeEqualTo "10 000,01"
+            handlebars.compileInline("{{ int_as_currency_no beløp_stor_integer }}").apply(context) shouldBeEqualTo "10 000,01"
+            handlebars.compileInline("{{ int_as_currency_no beløp_kjempestor_integer }}").apply(context) shouldBeEqualTo "21 474 836,47"
         }
     }
 


### PR DESCRIPTION
happy now, @TheUnnamedDude? this should cover ints up to 2417483647, it should be good enough for our use case

also, the locale setting produces non-breaking spaces which i would say is probably more correct than just spaces