### PR TITLE
Byttar til ein oppdatert fork av openHtmlToPdf-biblioteket. 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ val kluentVersion = "1.72"
 val ktorVersion = "2.3.9"
 val logbackVersion = "1.5.3"
 val logstashEncoderVersion = "7.4"
-val openHtmlToPdfVersion = "1.0.10"
+val openHtmlToPdfVersion = "1.1.4"
 val prometheusVersion = "0.16.0"
 val junitJupiterVersion = "5.10.2"
 val verapdfVersion = "1.24.1"
@@ -80,9 +80,9 @@ dependencies {
 
     implementation("com.github.jknack:handlebars:$handlebarsVersion")
     implementation("com.github.jknack:handlebars-jackson2:$handlebarsVersion")
-    implementation("com.openhtmltopdf:openhtmltopdf-pdfbox:$openHtmlToPdfVersion")
-    implementation("com.openhtmltopdf:openhtmltopdf-slf4j:$openHtmlToPdfVersion")
-    implementation("com.openhtmltopdf:openhtmltopdf-svg-support:$openHtmlToPdfVersion")
+    implementation("at.datenwort.openhtmltopdf:openhtmltopdf-pdfbox:$openHtmlToPdfVersion")
+    implementation("at.datenwort.openhtmltopdf:openhtmltopdf-slf4j:$openHtmlToPdfVersion")
+    implementation("at.datenwort.openhtmltopdf:openhtmltopdf-svg-support:$openHtmlToPdfVersion")
 
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,13 +10,13 @@ val kluentVersion = "1.72"
 val ktorVersion = "2.3.9"
 val logbackVersion = "1.5.3"
 val logstashEncoderVersion = "7.4"
-val openHtmlToPdfVersion = "1.1.4"
+val openHtmlToPdfVersion = "pdfbox2-65c2c5010f84b2daa5821971c9c68cd330463830"
 val prometheusVersion = "0.16.0"
 val junitJupiterVersion = "5.10.2"
 val verapdfVersion = "1.24.1"
 val ktfmtVersion = "0.44"
 val testcontainersVersion=  "1.19.6"
-val pdfgencoreVersion = "1.1.5"
+val pdfgencoreVersion = "1.1.8"
 
 
 plugins {
@@ -71,6 +71,13 @@ repositories {
     mavenLocal()
     maven {
         url = uri("https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
+    }
+    maven {
+        url = uri("https://maven.pkg.github.com/openhtmltopdf/openhtmltopdf")
+        credentials {
+            username = "token"
+            password = System.getenv("GITHUB_TOKEN")
+        }
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,7 +76,7 @@ repositories {
         url = uri("https://maven.pkg.github.com/openhtmltopdf/openhtmltopdf")
         credentials {
             username = "token"
-            password = System.getenv("GITHUB_TOKEN")
+            password = System.getenv("ORG_GRADLE_PROJECT_githubPassword")
         }
     }
 }

--- a/src/test/kotlin/no/nav/pdfgen/PdfGenITest.kt
+++ b/src/test/kotlin/no/nav/pdfgen/PdfGenITest.kt
@@ -17,8 +17,8 @@ import java.nio.file.Paths
 import java.util.concurrent.Executors
 import kotlinx.coroutines.*
 import no.nav.pdfgen.core.Environment
-import org.apache.pdfbox.Loader
 import org.apache.pdfbox.io.IOUtils
+import org.apache.pdfbox.pdmodel.PDDocument
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -64,7 +64,7 @@ internal class PdfGenITest {
                 val bytes = runBlocking { response.readBytes() }
                 assertNotEquals(null, bytes)
                 // Load the document in pdfbox to ensure it's valid
-                val document = Loader.loadPDF(bytes)
+                val document = PDDocument.load(bytes)
                 assertNotEquals(null, document)
                 assertEquals(true, document.pages.count > 0)
                 println(document.documentInformation.title)
@@ -115,7 +115,7 @@ internal class PdfGenITest {
         assertNotEquals(null, bytes)
         Files.write(Paths.get("build", "html.pdf"), bytes)
         // Load the document in pdfbox to ensure its valid
-        val document = Loader.loadPDF(bytes)
+        val document = PDDocument.load(bytes)
         assertNotEquals(null, document)
         assertEquals(true, document.pages.count > 0)
         println(document.documentInformation.title)
@@ -156,7 +156,7 @@ internal class PdfGenITest {
                             assertEquals(false, bytes.isEmpty())
                             Files.write(Paths.get("build", outputFile), bytes)
                             // Load the document in pdfbox to ensure its valid
-                            val document = Loader.loadPDF(bytes)
+                            val document = PDDocument.load(bytes)
                             assertNotEquals(null, document)
                             assertEquals(true, document.pages.count > 0)
                             document.close()

--- a/src/test/kotlin/no/nav/pdfgen/PdfGenITest.kt
+++ b/src/test/kotlin/no/nav/pdfgen/PdfGenITest.kt
@@ -17,8 +17,8 @@ import java.nio.file.Paths
 import java.util.concurrent.Executors
 import kotlinx.coroutines.*
 import no.nav.pdfgen.core.Environment
+import org.apache.pdfbox.Loader
 import org.apache.pdfbox.io.IOUtils
-import org.apache.pdfbox.pdmodel.PDDocument
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -64,7 +64,7 @@ internal class PdfGenITest {
                 val bytes = runBlocking { response.readBytes() }
                 assertNotEquals(null, bytes)
                 // Load the document in pdfbox to ensure it's valid
-                val document = PDDocument.load(bytes)
+                val document = Loader.loadPDF(bytes)
                 assertNotEquals(null, document)
                 assertEquals(true, document.pages.count > 0)
                 println(document.documentInformation.title)
@@ -115,7 +115,7 @@ internal class PdfGenITest {
         assertNotEquals(null, bytes)
         Files.write(Paths.get("build", "html.pdf"), bytes)
         // Load the document in pdfbox to ensure its valid
-        val document = PDDocument.load(bytes)
+        val document = Loader.loadPDF(bytes)
         assertNotEquals(null, document)
         assertEquals(true, document.pages.count > 0)
         println(document.documentInformation.title)
@@ -156,7 +156,7 @@ internal class PdfGenITest {
                             assertEquals(false, bytes.isEmpty())
                             Files.write(Paths.get("build", outputFile), bytes)
                             // Load the document in pdfbox to ensure its valid
-                            val document = PDDocument.load(bytes)
+                            val document = Loader.loadPDF(bytes)
                             assertNotEquals(null, document)
                             assertEquals(true, document.pages.count > 0)
                             document.close()


### PR DESCRIPTION
Den opphavlege blir ikkje lenger oppdatert, ref https://github.com/danfickle/openhtmltopdf/issues/921.

Den nye har ein litt kuriøs groupid i Maven central, men det er denne forken: https://github.com/openhtmltopdf/openhtmltopdf , som er nyleg oppdatert og verkar ganske real. Det er den som er peika på som der dei gjer vidareutvikling også i tråden over.

Ref også https://nav-it.slack.com/archives/C60FFACN5/p1696243986018369

Ser dog at første commit etter flyttinga over til ny GitHub-organisasjon er å oppgradere PDFBox frå 2 til 3, så mogleg det trengs endringar også i denne kodebasen for å kunne gjera det?