### PR TITLE
Sjekk om vi skal relaste environment på hvert kall

### DIFF
--- a/src/main/kotlin/no/nav/pdfgen/Bootstrap.kt
+++ b/src/main/kotlin/no/nav/pdfgen/Bootstrap.kt
@@ -79,7 +79,7 @@ fun initializeApplication(port: Int): ApplicationEngine {
         }
         install(
             createApplicationPlugin(name = "ReloadPDFGenCorePlugin") {
-                onCallReceive { call -> if (environment.isDevMode) PDFGenCore.reloadEnvironment() }
+                onCall { _ -> if (environment.isDevMode) PDFGenCore.reloadEnvironment() }
             }
         )
         routing {


### PR DESCRIPTION
Jeg vet ikke om dette er den beste fiksen, men`onCallReceive` trigges ikke av GET-requestet, så det gjør det litt kjedelig å utvikle lokalt uten å kunne se endringer etter hver request.

