### PR TITLE
Loglevel for PDFBox

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -5,12 +5,14 @@
             <provider class="net.logstash.logback.composite.loggingevent.ArgumentsJsonProvider" />
         </encoder>
     </appender>
-    
+
     <logger name="pdfgen" level="INFO"/>
 
     <root level="INFO">
         <appender-ref ref="stdout_json" />
     </root>
+
+    <logger name="org.apache.pdfbox" level="ERROR" />
 
 </configuration>
 


### PR DESCRIPTION
Vi får mange av disse i loggene, så ser helst at vi filtrerer bort ikke-actionable loggmeldinger. 

Dette er altså et veldig fort og gæli forsøk :) 

<img width="1322" alt="image" src="https://github.com/user-attachments/assets/159966aa-1884-450c-a19b-db0c128eb9f5">
