### PR TITLE
chore: Bump pdfgen-core version to 1.1.81

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ val junitJupiterVersion = "6.0.3"
 val verapdfVersion = "1.30.1"
 val ktfmtVersion = "0.44"
 val testcontainersVersion = "2.0.5"
-val pdfgencoreVersion = "1.1.80"
+val pdfgencoreVersion = "1.1.81"
 
 ///Due to vulnerabilities
 val commonsCompressVersion = "1.28.0"


### PR DESCRIPTION
Updated pdfgencoreVersion to address potential vulnerabilities.