### PR TITLE
fix: returner 422 i stedet for 500 ved ugyldig bildeformat

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ val prometheusVersion = "0.16.0"
 val junitJupiterVersion = "5.11.3"
 val verapdfVersion = "1.26.1"
 val ktfmtVersion = "0.44"
-val testcontainersVersion= "1.20.4"
+val testcontainersVersion = "1.20.4"
 val pdfgencoreVersion = "1.1.34"
 
 ///Due to vulnerabilities
@@ -101,6 +101,9 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
 
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
+    constraints {
+        implementation("io.netty:netty-common:4.1.115.Final")
+    }
     implementation("io.ktor:ktor-server-core:$ktorVersion")
     implementation("io.ktor:ktor-serialization-jackson:$ktorVersion")
     implementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ val verapdfVersion = "1.26.1"
 val ktfmtVersion = "0.44"
 val testcontainersVersion = "1.20.4"
 val pdfgencoreVersion = "1.1.34"
+val nettycommonVersion = "4.1.115.Final"
 
 ///Due to vulnerabilities
 val commonsCompressVersion = "1.27.1"
@@ -102,7 +103,7 @@ dependencies {
 
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
     constraints {
-        implementation("io.netty:netty-common:4.1.115.Final")
+        implementation("io.netty:netty-common:$nettycommonVersion")
     }
     implementation("io.ktor:ktor-server-core:$ktorVersion")
     implementation("io.ktor:ktor-serialization-jackson:$ktorVersion")

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -13,5 +13,7 @@
         <appender-ref ref="stdout_json" />
     </root>
 
+    <logger name="org.apache.pdfbox" level="ERROR" />
+
 </configuration>
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -13,7 +13,5 @@
         <appender-ref ref="stdout_json" />
     </root>
 
-    <logger name="org.apache.pdfbox" level="ERROR" />
-
 </configuration>
 


### PR DESCRIPTION
## Problem

Observert i produksjon (aap namespace) kl. 09:29–09:30 i dag:

```
java.lang.IllegalArgumentException: Unknown image type 0
  at java.awt.image.BufferedImage.<init>(Unknown Source)
  at no.nav.pdfgen.core.util.ImageKt.toPortait(Image.kt:24)
  at no.nav.pdfgen.core.pdf.CreatePdfKt.createPDFA(CreatePdf.kt:90)
  at no.nav.pdfgen.application.api.pdf.GeneratePdfApiKt$registerGeneratePdfApi...
```

En bruker lastet opp et bilde via `/api/vedlegginnsending/lagre` i innsending. Filen hadde Content-Type `image/jpeg` eller `image/png`, men inneholdt et bilde med en tilpasset `ColorModel` ([`BufferedImage.TYPE_CUSTOM = 0`](https://docs.oracle.com/en/java/docs/api/java.desktop/java/awt/image/BufferedImage.html#TYPE_CUSTOM)) som ikke støttes av `AffineTransformOp`.

Resultatet var at innsending fikk HTTP 500, retrydet 3 ganger, og feilen ble aldri kommunisert til brukeren.

## Løsning

Legger til `try-catch` rundt `createPDFA(inputStream, outputStream)` i `/image/{applicationName}`-endepunktet. Ugyldige bilder returnerer nå **HTTP 422 Unprocessable Entity** med en forklarende feilmelding.

## Rotkause

Rotkausen er i `pdfgen-core`: `toPortait()` i `Image.kt` normaliserer ikke `TYPE_CUSTOM`-bilder før rotasjon. Se tilhørende PR: https://github.com/navikt/pdfgen-core/compare/main...FredrikMeyer:pdfgen-core:fix/handle-custom-image-type-v2

## Observerbarhet

Funnet via:
- **Loki**: `{service_namespace="aap",service_name="pdfgen"} |= "Caught exception"`
- **Tempo**: trace `798575af231fcb2c15022b6dd55fff8a` viser full call chain fra bruker → innsending → pdfgen