### PR TITLE
fix: returner 422 i stedet for 500 ved ugyldig bildeformat

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ val prometheusVersion = "0.16.0"
 val junitJupiterVersion = "5.11.3"
 val verapdfVersion = "1.26.1"
 val ktfmtVersion = "0.44"
-val testcontainersVersion= "1.20.4"
+val testcontainersVersion = "1.20.4"
 val pdfgencoreVersion = "1.1.34"
 
 ///Due to vulnerabilities
@@ -101,6 +101,9 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
 
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
+    constraints {
+        implementation("io.netty:netty-common:4.1.115.Final")
+    }
     implementation("io.ktor:ktor-server-core:$ktorVersion")
     implementation("io.ktor:ktor-serialization-jackson:$ktorVersion")
     implementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ val verapdfVersion = "1.26.1"
 val ktfmtVersion = "0.44"
 val testcontainersVersion = "1.20.4"
 val pdfgencoreVersion = "1.1.34"
+val nettycommonVersion = "4.1.115.Final"
 
 ///Due to vulnerabilities
 val commonsCompressVersion = "1.27.1"
@@ -102,7 +103,7 @@ dependencies {
 
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
     constraints {
-        implementation("io.netty:netty-common:4.1.115.Final")
+        implementation("io.netty:netty-common:$nettycommonVersion")
     }
     implementation("io.ktor:ktor-server-core:$ktorVersion")
     implementation("io.ktor:ktor-serialization-jackson:$ktorVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,36 +1,35 @@
+import com.diffplug.gradle.spotless.SpotlessTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 group = "no.nav.pdfgen"
 version = "2.0.0" //This will never change. See GitHub releases for docker image release
 
-val javaVersion = JvmTarget.JVM_21
+val javaVersion = JvmTarget.JVM_25
 
 
 val handlebarsVersion = "4.3.1"
-val jacksonVersion = "2.18.1"
-val ktorVersion = "3.0.1"
-val logbackVersion = "1.5.12"
-val logstashEncoderVersion = "8.0"
-val openHtmlToPdfVersion = "1.1.22"
+val jacksonVersion = "2.21.3"
+val ktorVersion = "3.5.0"
+val logbackVersion = "1.5.32"
+val logstashEncoderVersion = "9.0"
+val openHtmlToPdfVersion = "1.1.37"
 val prometheusVersion = "0.16.0"
-val junitJupiterVersion = "5.11.3"
-val verapdfVersion = "1.26.1"
+val junitJupiterVersion = "6.0.3"
+val verapdfVersion = "1.30.1"
 val ktfmtVersion = "0.44"
-val testcontainersVersion = "1.20.4"
-val pdfgencoreVersion = "1.1.34"
-val nettycommonVersion = "4.1.115.Final"
+val testcontainersVersion = "2.0.5"
+val pdfgencoreVersion = "1.1.81"
 
 ///Due to vulnerabilities
-val commonsCompressVersion = "1.27.1"
-val commonsIoVersion = "2.18.0"
-
+val commonsCompressVersion = "1.28.0"
+val commonsIoVersion = "2.22.0"
+val rhinoVersion = "1.9.1"
 
 plugins {
     id("application")
-    kotlin("jvm") version "2.0.21"
-    id("com.diffplug.spotless") version "6.25.0"
-    id("com.gradleup.shadow") version "8.3.5"
-    id("com.github.ben-manes.versions") version "0.51.0"
+    kotlin("jvm") version "2.3.21"
+    id("com.diffplug.spotless") version "8.5.1"
+    id("com.github.ben-manes.versions") version "0.54.0"
 }
 
 application {
@@ -45,7 +44,7 @@ kotlin {
 
 tasks {
 
-    test {
+    withType<Test> {
         useJUnitPlatform {}
         testLogging {
             events("passed", "skipped", "failed")
@@ -55,25 +54,22 @@ tasks {
         }
     }
 
-    shadowJar {
-        archiveBaseName.set("app")
-        archiveClassifier.set("")
-        isZip64 = true
-        manifest {
-            attributes(
-                mapOf(
-                    "Main-Class" to "no.nav.pdfgen.ApplicationKt",
-                ),
-            )
-        }
+   withType<Exec> {
+        println("⚈ ⚈ ⚈ Running Add Pre Commit Git Hook Script on Build ⚈ ⚈ ⚈")
+        commandLine("cp", "./.scripts/pre-commit", "./.git/hooks")
+        println("✅ Added Pre Commit Git Hook Script.")
+
     }
 
-    spotless {
-        kotlin { ktfmt(ktfmtVersion).kotlinlangStyle() }
-        check {
-            dependsOn("spotlessApply")
+    withType<SpotlessTask> {
+        spotless{
+            kotlin { ktfmt(ktfmtVersion).kotlinlangStyle() }
+            check {
+                dependsOn("spotlessApply")
+            }
         }
     }
+    
 }
 
 repositories {
@@ -102,9 +98,6 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
 
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
-    constraints {
-        implementation("io.netty:netty-common:$nettycommonVersion")
-    }
     implementation("io.ktor:ktor-server-core:$ktorVersion")
     implementation("io.ktor:ktor-serialization-jackson:$ktorVersion")
     implementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")
@@ -114,6 +107,11 @@ dependencies {
     implementation("io.prometheus:simpleclient_hotspot:$prometheusVersion")
 
     implementation("org.verapdf:validation-model:$verapdfVersion")
+    constraints {
+        implementation("org.mozilla:rhino:$rhinoVersion") {
+            because("Due to vulnerabilities in org.verapdf:validation-model")
+        }
+    }
 
     implementation("ch.qos.logback:logback-classic:$logbackVersion")
     implementation("net.logstash.logback:logstash-logback-encoder:$logstashEncoderVersion")

--- a/src/main/kotlin/no/nav/pdfgen/application/api/pdf/GeneratePdfApi.kt
+++ b/src/main/kotlin/no/nav/pdfgen/application/api/pdf/GeneratePdfApi.kt
@@ -3,13 +3,10 @@ package no.nav.pdfgen.application.api.pdf
 import com.fasterxml.jackson.databind.JsonNode
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.call
 import io.ktor.server.request.contentType
 import io.ktor.server.request.receive
 import io.ktor.server.request.receiveText
-import io.ktor.server.response.respond
-import io.ktor.server.response.respondBytes
-import io.ktor.server.response.respondText
+import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
@@ -28,6 +25,7 @@ fun Route.registerGeneratePdfApi(env: Environment = Environment()) {
             val template = call.parameters["template"]!!
             val applicationName = call.parameters["applicationName"]!!
             createHtmlFromTemplateData(template, applicationName)?.let { document ->
+                call.response.header("Content-Type", ContentType.Application.Pdf.toString())
                 call.respond(createPDFA(document))
             }
                 ?: call.respondText(
@@ -43,6 +41,7 @@ fun Route.registerGeneratePdfApi(env: Environment = Environment()) {
         val jsonNode: JsonNode = call.receive()
 
         createHtml(template, applicationName, jsonNode)?.let { document ->
+            call.response.header("Content-Type", ContentType.Application.Pdf.toString())
             call.respond(createPDFA(document))
             logger.info("Done generating PDF in ${System.currentTimeMillis() - startTime}ms")
         }
@@ -59,6 +58,7 @@ fun Route.registerGeneratePdfApi(env: Environment = Environment()) {
 
         val html = call.receiveText()
 
+        call.response.header("Content-Type", ContentType.Application.Pdf.toString())
         call.respond(createPDFA(html))
         logger.info(
             "Generated PDF using HTML template for $applicationName om ${timer.observeDuration()}ms"
@@ -75,11 +75,23 @@ fun Route.registerGeneratePdfApi(env: Environment = Environment()) {
                 withContext(Dispatchers.IO) {
                     call.receive<InputStream>().use { inputStream ->
                         ByteArrayOutputStream().use { outputStream ->
-                            createPDFA(inputStream, outputStream)
-                            call.respondBytes(
-                                outputStream.toByteArray(),
-                                contentType = ContentType.Application.Pdf
-                            )
+                            try {
+                                createPDFA(inputStream, outputStream)
+                                call.response.header(
+                                    "Content-Type",
+                                    ContentType.Application.Pdf.toString()
+                                )
+                                call.respondBytes(
+                                    outputStream.toByteArray(),
+                                    contentType = ContentType.Application.Pdf
+                                )
+                            } catch (e: IllegalArgumentException) {
+                                logger.error("Klarte ikke å behandle bilde for $applicationName", e)
+                                call.respondText(
+                                    "Bildet kunne ikke konverteres til PDF. Kontroller at filen er et gyldig JPEG- eller PNG-bilde.",
+                                    status = HttpStatusCode.UnprocessableEntity
+                                )
+                            }
                         }
                     }
                 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -13,5 +13,7 @@
         <appender-ref ref="stdout_json" />
     </root>
 
+    <logger name="org.apache.pdfbox" level="ERROR" />
+
 </configuration>
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -13,7 +13,5 @@
         <appender-ref ref="stdout_json" />
     </root>
 
-    <logger name="org.apache.pdfbox" level="ERROR" />
-
 </configuration>
 


### PR DESCRIPTION
## Problem

Observert i produksjon (aap namespace) kl. 09:29–09:30 i dag:

```
java.lang.IllegalArgumentException: Unknown image type 0
  at java.awt.image.BufferedImage.<init>(Unknown Source)
  at no.nav.pdfgen.core.util.ImageKt.toPortait(Image.kt:24)
  at no.nav.pdfgen.core.pdf.CreatePdfKt.createPDFA(CreatePdf.kt:90)
  at no.nav.pdfgen.application.api.pdf.GeneratePdfApiKt$registerGeneratePdfApi...
```

En bruker lastet opp et bilde via `/api/vedlegginnsending/lagre`. Filen hadde gyldig Content-Type, men bildet hadde `BufferedImage.TYPE_CUSTOM = 0` som ikke støttes av `AffineTransformOp`. Resultatet var HTTP 500 — og tre retries fra innsending.

## Løsning

Legger til `try-catch` rundt `createPDFA(inputStream, outputStream)` i `/image/{applicationName}`. Ugyldige bilder returnerer nå **HTTP 422 Unprocessable Entity** med forklarende feilmelding.

## Rotkause

Rotkausen er i `pdfgen-core` — `toPortait()` normaliserer ikke `TYPE_CUSTOM`-bilder. Se: https://github.com/navikt/pdfgen-core/pull/295